### PR TITLE
Fix error thrown on empty keys

### DIFF
--- a/lib/mdconf.js
+++ b/lib/mdconf.js
@@ -68,7 +68,11 @@ function put(obj, keys, str, normalize, code) {
   var target = obj;
   var last;
 
-  for (var i = 0; i < keys.length; i++) {
+  // require keys
+  var len = keys.length;
+  if (len === 0) return;
+
+  for (var i = 0; i < len; i++) {
     var key = keys[i];
     last = target;
     target[key] = target[key] || {};


### PR DESCRIPTION
My project was failing to load config.md as an exception was thrown when parsing empty headings.

```
TypeError: Cannot read property 'undefined' of undefined
at put (***/node_modules/gulp-styledown/node_modules/styledown/lib/mdconf.js:91:28)
at ***/node_modules/gulp-styledown/node_modules/styledown/lib/mdconf.js:45:9
at Array.forEach (native)
at module.exports (***/node_modules/gulp-styledown/node_modules/styledown/lib/mdconf.js:31:8)
at exports.processConfig (***/node_modules/gulp-styledown/node_modules/styledown/lib/filters.js:95:16)
at Object.Styledown.process (***/node_modules/gulp-styledown/node_modules/styledown/index.js:212:5)
at Object.Styledown (***/node_modules/gulp-styledown/node_modules/styledown/index.js:106:8)
at Function.Styledown.parse (***/node_modules/gulp-styledown/node_modules/styledown/index.js:59:10)
at DestroyableTransform.flush [as _flush] (***/node_modules/gulp-styledown/index.js:55:24)
at DestroyableTransform.<anonymous> (***/node_modules/gulp-styledown/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:135:12)
```
