### PR TITLE
Add --case-sensitive option

### DIFF
--- a/bin/styledown
+++ b/bin/styledown
@@ -3,8 +3,8 @@ var Styledown = require('..'),
     read = require('read-input');
 
 var args = require('minimist')(process.argv.slice(2), {
-  boolean: ['inline', 'css', 'js', 'conf', 'quiet'],
-  alias: { h: 'help', v: 'version', i: 'inline', o: 'output', q: 'quiet' }
+  boolean: ['inline', 'css', 'js', 'conf', 'quiet', 'case-sensitive'],
+  alias: { h: 'help', v: 'version', i: 'inline', o: 'output', q: 'quiet', s: 'case-sensitive' }
 });
 
 if (args.help) {
@@ -18,6 +18,7 @@ if (args.help) {
       '    -h, --help           print usage information',
       '    -v, --version        show version info and exit',
       '    -i, --inline         force extracts from inline CSS comments (for piping)',
+      '    -s, --case-sensitive case sensitive parser (less performant but will work with SVG and other case sensitive markup strings)',
       '    -o, --output FILE    write output a file',
       '',
       'Support files:',
@@ -62,7 +63,8 @@ read(args._, function (err, res) {
 
   var ms = measure(function () {
     html = Styledown.parse(res.files, {
-      inline: args.inline
+      inline: args.inline,
+      caseSensitive: args['case-sensitive']
     }) + "\n";
   });
 

--- a/index.js
+++ b/index.js
@@ -213,6 +213,7 @@ Styledown.prototype = {
     removeConfig(this.$);
 
     var pre = this.options.prefix;
+    var caseSensitive = this.options.caseSensitive;
     var $ = this.$;
 
     addClasses($, p);
@@ -220,7 +221,7 @@ Styledown.prototype = {
     sectionize($, 'h2', p, { 'class': p('section'), until: 'h1, h2' });
 
     $('pre').each(function () {
-      unpackExample($(this), p, highlightHTML);
+      unpackExample($(this), p, highlightHTML, caseSensitive);
     });
 
     isolateTextBlocks(this.$, p);

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -47,7 +47,6 @@ exports.unpackExample = function (parent, pre, highlight, caseSensitive) {
   var tags = parseTags(block.tag);
 
   var cheeOpts = { lowerCaseTags: !caseSensitive, lowerCaseAttributeNames: !caseSensitive };
-  console.log(cheeOpts);
 
   if (tags.example) {
     var html = htmlize(block.code);

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -40,17 +40,20 @@ exports.sectionize = function ($, tag, pre, options) {
  * Unpacks `pre` blocks into examples.
  */
 
-exports.unpackExample = function (parent, pre, highlight) {
+exports.unpackExample = function (parent, pre, highlight, caseSensitive) {
   var Cheerio = require('cheerio');
   var code = parent.text();
   var block = parseCodeText(code);
   var tags = parseTags(block.tag);
 
+  var cheeOpts = { lowerCaseTags: !caseSensitive, lowerCaseAttributeNames: !caseSensitive };
+  console.log(cheeOpts);
+
   if (tags.example) {
     var html = htmlize(block.code);
     var canvas = "<div class='"+pre('canvas')+"'>"+html+"</div>";
     var codeblock = "<pre class='"+pre('code')+"'>"+highlight(html)+"</pre>";
-    var $block = Cheerio.load("<div class='"+pre('example')+"'>" + canvas + codeblock + "</div>");
+    var $block = Cheerio.load("<div class='"+pre('example')+"'>" + canvas + codeblock + "</div>", cheeOpts);
 
     if (tags['class']) {
       klass = pre(tags['class']);

--- a/test/cli.coffee
+++ b/test/cli.coffee
@@ -44,6 +44,20 @@ describe 'CLI:', ->
       expect(result.out).match /<h3[^>]*>hi<\/h3>/
       expect(result.out).match /<p[^>]*>there<\/p>/
 
+  describe 'case sensitive', ->
+    pipe """
+    /**
+     * Hi:
+     *
+     *     @example
+     *     <h1 caseSensitiveTag="foo"></h1>
+     */
+    """, ['--inline', '--case-sensitive']
+    success()
+
+    it 'keeps HTML casing.', ->
+      expect(result.out).contain '<h1 caseSensitiveTag="foo">'
+
   describe 'pipe --inline', ->
     pipe """
     /**

--- a/test/pre_tag.coffee
+++ b/test/pre_tag.coffee
@@ -90,3 +90,5 @@ describe 'Pre tag', ->
 
     it 'makes a <pre> HTML code', ->
       expect(@$("pre").text()).eql '<div class="button"></div>'
+
+

--- a/test/setup.coffee
+++ b/test/setup.coffee
@@ -14,7 +14,7 @@ before ->
     options.head ?= false
     @sd = new Styledown(html, options)
     @html = @sd.toHTML()
-    @$ = Cheerio.load(@html)
+    @$ = Cheerio.load(@html, lowerCaseTags: false, lowerCaseAttributeNames: false)
 
 chai.Assertion.addMethod 'htmleql', (val, msg) ->
   a = Cheerio.load(@_obj, normalizeWhitespace: true).html()

--- a/test/syntax.coffee
+++ b/test/syntax.coffee
@@ -40,3 +40,29 @@ describe 'Syntax highlight', ->
       expect(@$('.sg-code .hljs-attribute').length).gte 2
       expect(@$('.sg-code').html()).match /&lt;/
 
+  describe 'case insensitive code examples', ->
+    beforeEach ->
+      @load '''
+      ### hello
+
+          @example
+          <div myAngularAttribute="true"></div>
+      ''', caseSensitive: false
+
+    it 'keeps the original case', ->
+      expect(@$('[myAngularAttribute]').length).eq 0
+      expect(@$('[myangularattribute]').length).eq 1
+
+  describe 'case sensitive code examples', ->
+    beforeEach ->
+      @load '''
+      ### hello
+
+          @example
+          <div myAngularAttribute="true"></div>
+      ''', caseSensitive: true
+
+    it 'keeps the original case', ->
+      expect(@$('[myAngularAttribute]').length).eq 1
+      expect(@$('[myangularattribute]').length).eq 0
+


### PR DESCRIPTION
**What does this PR do?**
Adds a new `--case-sensitive` option that forces the HTML generated by Styledown to retain attribute and element casing. This is useful for SVG and Angular2 markup where case sensitivity is important.